### PR TITLE
Add test case for  #city_openings

### DIFF
--- a/spec/models/city_spec.rb
+++ b/spec/models/city_spec.rb
@@ -12,6 +12,7 @@ describe City do
   describe 'instance methods' do
     it 'knows about all the available listings given a date range' do
       expect(City.first.city_openings('2014-05-01', '2014-05-05')).to include(@listing2,@listing3) 
+      expect(City.first.city_openings('2014-05-01', '2014-05-05')).to_not include(@listing1)
     end 
   end
 


### PR DESCRIPTION
Only checking for listings that should be returned for **#city_openings** leads to a false negative situation, as returning just `Listing.all` would pass the test.
