### PR TITLE
correct host_reviews association

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,5 +10,5 @@ class User < ActiveRecord::Base
 
   ## As a host
   has_many :guests, :through => :reservations, :class_name => "User"
-  has_many :host_reviews, :through => :guests, :source => :reviews
+  has_many :host_reviews, :through => :listings, :source => :reviews
 end


### PR DESCRIPTION
`through: :guests` would return every review a guest has ever left, regardless of whether it pertains to a property owned by the given host.
