### PR TITLE
Added sprockets with version minimum to fix an issue when trying to m…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'sass-rails'
 gem 'sdoc', '~> 0.4.0',          group: :doc
 gem 'uglifier'
 gem 'bootsnap'
+gem 'sprockets', '~>3.0'
 
 gem 'sqlite3', '~>1.3.6'
 


### PR DESCRIPTION
Received the following error when trying to migrate upon downloading:
`$ rake db:migrate
rake aborted!
Sprockets::Railtie::ManifestNeededError: Expected to find a manifest file in `app/assets/config/manifest.js`
But did not, please create this file and use it to link any assets that need
to be rendered by your app:

Example:
  //= link_tree ../images
  //= link_directory ../javascripts .js
  //= link_directory ../stylesheets .css
and restart your server

For more information see: https://github.com/rails/sprockets/blob/070fc01947c111d35bb4c836e9bb71962a8e0595/UPGRADING.md#manifestjs
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/sprockets-rails-3.2.2/lib/sprockets/railtie.rb:106:in `block in <class:Railtie>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/railties-5.0.7.1/lib/rails/initializable.rb:30:in `instance_exec'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/railties-5.0.7.1/lib/rails/initializable.rb:30:in `run'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/railties-5.0.7.1/lib/rails/initializable.rb:55:in `block in run_initializers'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/railties-5.0.7.1/lib/rails/initializable.rb:54:in `run_initializers'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/railties-5.0.7.1/lib/rails/application.rb:352:in `initialize!'
/Users/Brazenbillygoat/Desktop/Coding/flatiron/code/phase-two-rails-html/module-lab-sections/associations-and-rails/bnb-methods/config/environment.rb:5:in `<top (required)>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/railties-5.0.7.1/lib/rails/application.rb:328:in `require'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/railties-5.0.7.1/lib/rails/application.rb:328:in `require_environment!'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/railties-5.0.7.1/lib/rails/application.rb:448:in `block in run_tasks_blocks'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/bin/ruby_executable_hooks:24:in `eval'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => db:migrate => environment
(See full trace by running task with --trace)`

Addition to the Gemfile fixes the issue.